### PR TITLE
Network type toggle

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -10,25 +10,12 @@ import { actions } from '../store/userStore';
 import { localStorageKeys } from '../tokens';
 import { getItem, setItem } from '../localStorage';
 
-const requestTimeoutMs = 120000;
 const baseURL: string = get(process.env, 'REACT_APP_API_BASE_URL', 'http://localhost:3000');
 const apiVersion: string = get(process.env, 'REACT_APP_API_VERSION', 'v1');
-const baseURLCardano: string = get(process.env, 'REACT_APP_CARDANO_API_BASE_URL', 'http://127.0.0.1:5000');
-const apiVersionCardano: string = get(process.env, 'REACT_APP_CARDANO_API_VERSION', 'v1');
 
 const apiClient: any = axios.create({
   baseURL: `${baseURL}/api/${apiVersion}`,
   timeout: minutesToMilliseconds(1),
-  headers: {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    Accept: '*/*',
-  },
-});
-
-export const apiClientCardano: any = axios.create({
-  baseURL: `${baseURLCardano}/api/${apiVersionCardano}`,
-  timeout: requestTimeoutMs,
   headers: {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*',

--- a/src/assets/stylesheets/pages.user.scss
+++ b/src/assets/stylesheets/pages.user.scss
@@ -33,6 +33,15 @@
       width: 100%;
     }
 
+    .user-section-wrapper-toggle {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        gap: 20px;
+       }
+
     .user-page-hero {
       display: flex;
       flex-direction: column;

--- a/src/components/modal/TreasuryModal.js
+++ b/src/components/modal/TreasuryModal.js
@@ -44,7 +44,6 @@ function TreasuryModal({ onClose, type }: Props): Node {
   const sumbitFill = (signature_: string, tx: string, articleId: number) => dispatch(actions.sumbitFill(signature_, tx, articleId));
   const submitSpend = (signature_: string, tx: string, articleId: number, ws: string) => dispatch(actions.submitSpend(signature_, tx, articleId, ws));
   const clearTx = () => dispatch(actions.clearTx());
-  // const networkType = process.env.REACT_APP_CARDANO_NETWORK_TYPE || 'testnet';
 
   const [nextButtonDisabled, setNextButtonDisabled] = useState(false);
   const [activeStep, setActiveStep] = React.useState(0);
@@ -74,23 +73,6 @@ function TreasuryModal({ onClose, type }: Props): Node {
       setActiveStep(2);
     }
   }, [signature]);
-
-  // const {
-  //   // isEnabled,
-  //   // isConnected,
-  //   // enabledWallet,
-  //   // stakeAddress,
-  //   // accountBalance,
-  //   // signMessage,
-  //   // usedAddresses,
-  //   // enabledWallet,
-  //   // installedExtensions,
-  //   // connect,
-  //   // disconnect,
-  //   // connectedCip45Wallet,
-  // } = useCardano({
-  //   limitNetwork: networkType,
-  // });
 
   const errorList = {
     isEmpty: 'isEmpty',

--- a/src/components/pages/ArticleSettings.js
+++ b/src/components/pages/ArticleSettings.js
@@ -27,7 +27,11 @@ import { actions, selectors } from '../../store/articleStore';
 // eslint-disable-next-line no-unused-vars
 import { actions as cardanoActions, selectors as cardanoSelectors } from '../../store/cardanoStore';
 import { selectors as userSelectors } from '../../store/userStore';
-import { getSmallReviewCount, getWordCount } from '../../utils/hooks';
+import {
+  getSmallReviewCount,
+  getWordCount,
+  useNetworkToggle,
+} from '../../utils/hooks';
 import HowItWorks from '../modal/HowItWorks';
 import Conditions from '../modal/Conditions';
 import Input from '../elements/Input';
@@ -462,7 +466,9 @@ function ArticleSettings(): Node {
   const inlineReviews = groupBy(getSmallReviewCount(get(article, ['content', 'blocks'])),
     (smallReview) => smallReview.dataId);
 
-  const networkType = process.env.REACT_APP_CARDANO_NETWORK_TYPE || 'testnet';
+  // eslint-disable-next-line no-unused-vars
+  const [networkType, toggleNetworkType] = useNetworkToggle();
+
   const isAuthor = get(article, 'author.id') === get(user, 'id');
   const txAmount = get(article, 'tx_amount_in_treasury') || 0;
   const isArticleReady = () => !isEmpty(article) && id && get(article, 'id') === toInteger(id);

--- a/src/components/pages/UserPage.js
+++ b/src/components/pages/UserPage.js
@@ -20,7 +20,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { toast } from 'react-toastify';
 import {
-  Alert, AlertTitle, Button, Chip,
+  Alert, AlertTitle, Button, Chip, Switch,
 } from '@mui/material';
 import { ConnectWalletButton, useCardano } from '@cardano-foundation/cardano-connect-with-wallet';
 import { getWalletIcon } from '@cardano-foundation/cardano-connect-with-wallet-core';
@@ -29,6 +29,7 @@ import {
   emailChecks,
   nameChecks,
   uploadImage,
+  useNetworkToggle,
   usernameChecks,
 } from '../../utils/hooks';
 import UserSection from '../containers/UserSection';
@@ -79,7 +80,7 @@ function UserPage(): React$Node {
     });
   }, [user]);
 
-  const networkType = process.env.REACT_APP_CARDANO_NETWORK_TYPE || 'testnet';
+  const [networkType, toggleNetworkType] = useNetworkToggle();
 
   const {
     // isEnabled,
@@ -90,6 +91,7 @@ function UserPage(): React$Node {
     // signMessage,
     usedAddresses,
     enabledWallet,
+    // networkType,
     // installedExtensions,
     // connect,
     disconnect,
@@ -128,7 +130,9 @@ function UserPage(): React$Node {
     && (!get(user, 'wallet_address')
     || get(user, 'wallet_address') !== usedAddresses[0])) {
       setNewAddress(usedAddresses[0]);
+      console.log('setNewAddress', usedAddresses[0]);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [usedAddresses[0]]);
 
   const disconnectWallet = () => {
@@ -476,9 +480,31 @@ function UserPage(): React$Node {
             }}
           />
         </Alert>
-        )
-        }
-        { !isConnected && (
+        )}
+        <UserSection
+          title="Global settings"
+          expandedCard={expandedCard}
+          setExpandedCard={setExpandedCard}
+          variants={variants}
+          index={4}
+        >
+          <div className="user-section-wrapper-toggle">
+            <p>{networkType === 'mainnet' ? 'Mainnet' : 'Testnet'}</p>
+            <Switch
+              checked={networkType === 'mainnet'}
+              onChange={() => {
+                toggleNetworkType();
+                disconnectWallet();
+              }}
+              name="networkType"
+              color="primary"
+              inputProps={{ 'aria-label': 'primary checkbox' }}
+            />
+
+          </div>
+        </UserSection>
+
+        {!isConnected && (
         <ConnectWalletButton
           message="Connect wallet"
           limitNetwork={networkType}

--- a/src/store/cardanoStore.js
+++ b/src/store/cardanoStore.js
@@ -60,6 +60,8 @@ export const selectors = {
 
 };
 
+const networkType = localStorage.getItem('networkType') || process.env.REACT_APP_CARDANO_NETWORK_TYPE || 'testnet';
+
 export const actions = {
   fetchTreasury: (articleId: number, showMessage?: boolean): ReduxAction => ({
     type: types.WLT_FETCH_WALLET,
@@ -77,7 +79,7 @@ export const actions = {
 
     return {
       type: types.WLT_BUILD_FILL_TREASURY,
-      payload: API.postTreasury(payload),
+      payload: API.postTreasury({ ...payload, networkType }),
       propagate: {
         articleId: payload.articleId,
       },
@@ -92,7 +94,7 @@ export const actions = {
 
     return {
       type: types.WLT_BUILD_SPEND_TREASURY,
-      payload: API.postSpendTreasury(payload),
+      payload: API.postSpendTreasury({ ...payload, networkType }),
       propagate: {
         articleId: payload.articleId,
       },
@@ -112,6 +114,7 @@ export const actions = {
         witness: signature,
         article_id: id,
       },
+      networkType,
     }),
   }),
   clearTx: (): ReduxAction => ({
@@ -126,6 +129,7 @@ export const actions = {
         witness_set: ws,
         article_id: id,
       },
+      networkType,
     }),
   }),
 };

--- a/src/store/cardanoStore.js
+++ b/src/store/cardanoStore.js
@@ -60,7 +60,7 @@ export const selectors = {
 
 };
 
-const networkType = localStorage.getItem('networkType') || process.env.REACT_APP_CARDANO_NETWORK_TYPE || 'testnet';
+const networkType = localStorage.getItem('networkType') || 'testnet';
 
 export const actions = {
   fetchTreasury: (articleId: number, showMessage?: boolean): ReduxAction => ({

--- a/src/store/userStore.js
+++ b/src/store/userStore.js
@@ -224,7 +224,7 @@ export const reducer = (state: State, action: ReduxActionWithPayload): State => 
       return state;
 
     case types.USR_UPDATE_USER_FULFILLED:
-      toast.success('User successfully updated!');
+      // toast.success('User successfully updated!');
 
       return {
         ...state,

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -496,3 +496,17 @@ export function uploadByUrl(url: any): any {
   //   });
   // });
 }
+
+export const useNetworkToggle = (): [string, Function] => {
+  const initValue = localStorage.getItem('networkType') || process.env.REACT_APP_CARDANO_NETWORK_TYPE || 'testnet';
+
+  const [networkType, setNetworkType] = useState(initValue);
+
+  const toggleNetwork = () => {
+    const newNetworkType = networkType === 'testnet' ? 'mainnet' : 'testnet';
+    setNetworkType(newNetworkType);
+    localStorage.setItem('networkType', newNetworkType);
+  };
+
+  return [networkType, toggleNetwork];
+};

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -498,7 +498,7 @@ export function uploadByUrl(url: any): any {
 }
 
 export const useNetworkToggle = (): [string, Function] => {
-  const initValue = localStorage.getItem('networkType') || process.env.REACT_APP_CARDANO_NETWORK_TYPE || 'testnet';
+  const initValue = localStorage.getItem('networkType') || 'testnet';
 
   const [networkType, setNetworkType] = useState(initValue);
 

--- a/src/utils/lists.js
+++ b/src/utils/lists.js
@@ -2,12 +2,10 @@ import { forEach, join, pickBy } from 'lodash';
 
 export const envErrors = {
   REACT_APP_API_BASE_URL: null,
-  REACT_APP_CARDANO_API_BASE_URL: null,
   REACT_APP_CARDANO_NETWORK_TYPE: ['testnet', 'mainnet'],
 };
 
 export const envWarnings = {
-  REACT_APP_CARDANO_API_VERSION: ['v1'],
   REACT_APP_API_VERSION: ['v1'],
   REACT_APP_ORCID_CLIENT_ID: null,
   REACT_APP_UNSPLASH_ACCESS_KEY: null,

--- a/src/utils/lists.js
+++ b/src/utils/lists.js
@@ -2,7 +2,6 @@ import { forEach, join, pickBy } from 'lodash';
 
 export const envErrors = {
   REACT_APP_API_BASE_URL: null,
-  REACT_APP_CARDANO_NETWORK_TYPE: ['testnet', 'mainnet'],
 };
 
 export const envWarnings = {


### PR DESCRIPTION
Add a toggle to select network type. Possible options are testnet (usually preview testnet) and mainnet. The toggle button exists in the user profile but is applied site-wide. Another option is to include the button on the main toolbar if a user-connected wallet is detected.